### PR TITLE
Update URTouch.cpp

### DIFF
--- a/URTouch.cpp
+++ b/URTouch.cpp
@@ -39,7 +39,7 @@ URTouch::URTouch(byte tclk, byte tcs, byte din, byte dout, byte irq)
 	T_IRQ	= irq;
 }
 
-void URTouch::InitTouch(byte orientation, unsigned long cal_x = CAL_X, unsigned long cal_y = CAL_Y, unsigned long cal_s = CAL_S)
+void URTouch::InitTouch(byte orientation, unsigned long cal_x, unsigned long cal_y, unsigned long cal_s)
 {
 	orient					= orientation;
     


### PR DESCRIPTION
warning: default argument given for parameter 2 of 'void URTouch::InitTouch(byte, long unsigned int, long unsigned int, long unsigned int)' [-fpermissive]